### PR TITLE
fix: harden tests for create-client

### DIFF
--- a/packages/vs3/src/client/create-client.test.ts
+++ b/packages/vs3/src/client/create-client.test.ts
@@ -137,6 +137,35 @@ describe("createBaseClient", () => {
 			});
 		});
 
+		it("surfaces API errors from upload-url request", async () => {
+			const metadataSchema = z.object({ userId: z.string() });
+			const { createFetch } = await import("@better-fetch/fetch");
+			const mockFetchFn = vi.fn().mockResolvedValue({
+				error: { status: 400, message: "Bad Request" },
+				data: null,
+			});
+			(createFetch as ReturnType<typeof vi.fn>).mockReturnValue(mockFetchFn);
+
+			const client = createBaseClient({
+				baseURL: mockBaseURL,
+				apiPath: mockApiPath,
+				metadataSchema,
+			});
+
+			const mockFile = new File(["test content"], "test.txt", {
+				type: "text/plain",
+			});
+			const xhrUploadSpy = vi.spyOn(xhrUploadModule, "xhrUpload");
+
+			await expect(
+				client.uploadFile(mockFile, { userId: "user-1" }),
+			).rejects.toMatchObject({
+				code: StorageErrorCode.UNKNOWN_ERROR,
+				message: "Bad Request",
+			});
+			expect(xhrUploadSpy).not.toHaveBeenCalled();
+		});
+
 		it("calls onSuccess after upload completes", async () => {
 			const metadataSchema = z.object({
 				userId: z.string(),


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Hardened create-client upload tests to validate request payload and error handling. Added an explicit assertion for the upload-url fetch body and a test that surfaces API errors (e.g., 400 Bad Request) and ensures xhrUpload isn’t called on failure.

<sup>Written for commit 77374924b351d7425aadc765a6f54c04a4e925c6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

