### PR TITLE
fix: align StorageAPI type with actual endpoint implementation

### DIFF
--- a/packages/vs3/src/types/api.ts
+++ b/packages/vs3/src/types/api.ts
@@ -26,7 +26,7 @@ export type WithMetadata<
 type APIMethod<Body, Response> = (context: { body: Body }) => Promise<Response>;
 
 /**
- * Storage API with all endpoints
+ * Storage API with all available endpoints
  * Routes are automatically typed based on whether they require metadata
  */
 export type StorageAPI<O extends StorageOptions> = {
@@ -34,26 +34,16 @@ export type StorageAPI<O extends StorageOptions> = {
 	 * Generate a presigned upload URL
 	 * Requires metadata if metadataSchema is defined
 	 */
-	upload: APIMethod<
-		WithMetadata<{ file: File | FileInfo }, O, true>,
-		{ uploadUrl: string; uploadHeaders?: Record<string, string> }
-	>;
-
-	/**
-	 * Delete a file
-	 * Requires metadata if metadataSchema is defined
-	 */
-	delete: APIMethod<
-		WithMetadata<{ key: string }, O, true>,
-		{ success: boolean }
-	>;
-
-	/**
-	 * Generate a presigned download URL
-	 * Never requires metadata
-	 */
-	download: APIMethod<
-		WithMetadata<{ key: string }, O, false>,
-		{ downloadUrl: string }
+	uploadUrl: APIMethod<
+		WithMetadata<
+			{
+				fileInfo: FileInfo;
+				expiresIn?: number;
+				acl?: "public-read" | "private";
+			},
+			O,
+			true
+		>,
+		{ presignedUrl: string; key: string }
 	>;
 };


### PR DESCRIPTION
The StorageAPI type defined three endpoints (upload, delete, download) that did not exist in the actual implementation. The only implemented endpoint is uploadUrl (/upload-url).

Updated StorageAPI to:
- Remove phantom delete and download endpoints
- Rename upload to uploadUrl to match implementation
- Update request body type to include fileInfo, expiresIn, and acl
- Update response type to match actual output (presignedUrl, key)

This ensures type safety by aligning the type definition with the runtime implementation in the route registry and router.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the StorageAPI type with the actual runtime by exposing only the uploadUrl endpoint and matching its request/response shapes. Prevents type drift and incorrect usage across the route registry and router.

- **Bug Fixes**
  - Removed non-existent delete and download endpoints.
  - Renamed upload to uploadUrl to match the /upload-url route.
  - Updated request body to { fileInfo, expiresIn?, acl } and response to { presignedUrl, key }.

<sup>Written for commit 79558bc35ef65e2415c304dc595ba29c81a08e2b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

