### PR TITLE
fix(client): xhr upload correctly handles cleanup

### DIFF
--- a/apps/dev/tsconfig.json
+++ b/apps/dev/tsconfig.json
@@ -9,21 +9,22 @@
 		"moduleDetection": "force",
 		"isolatedModules": true,
 		"verbatimModuleSyntax": true,
-
 		/* Strictness */
 		"strict": true,
 		"noUncheckedIndexedAccess": true,
 		"checkJs": true,
-
 		/* Bundled projects */
 		"lib": ["dom", "dom.iterable", "ES2022"],
 		"noEmit": true,
 		"module": "ESNext",
 		"moduleResolution": "Bundler",
-		"jsx": "preserve",
-		"plugins": [{ "name": "next" }],
+		"jsx": "react-jsx",
+		"plugins": [
+			{
+				"name": "next"
+			}
+		],
 		"incremental": true,
-
 		/* Path Aliases */
 		"baseUrl": ".",
 		"paths": {
@@ -36,7 +37,8 @@
 		"**/*.tsx",
 		"**/*.cjs",
 		"**/*.js",
-		".next/types/**/*.ts"
+		".next/types/**/*.ts",
+		".next/dev/types/**/*.ts"
 	],
 	"exclude": ["node_modules", "generated"]
 }

--- a/packages/vs3/src/client/xhr/xhr-factory.ts
+++ b/packages/vs3/src/client/xhr/xhr-factory.ts
@@ -25,11 +25,11 @@ export class XhrFactory {
 		}
 	}
 
-	cleanup() {
+	cleanup = (): void => {
 		if (this.signal !== undefined && this.abortHandler !== undefined) {
 			this.signal.removeEventListener("abort", this.abortHandler);
 		}
-	}
+	};
 
 	/**
 	 * Takes in a Headers object and appends all of the headers to the


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes XHR upload cleanup by binding cleanup as an arrow function so abort listeners are removed reliably. Also updates the dev tsconfig to use react-jsx and include Next dev type paths.

- **Bug Fixes**
  - Bind cleanup as an arrow function to correctly detach the AbortSignal listener.

- **Refactors**
  - Switch JSX to react-jsx in apps/dev tsconfig.
  - Include .next/dev/types in TypeScript includes.

<sup>Written for commit 5456f28ce27d665f7a455c898e1454a2f2e41095. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

