### PR TITLE
build: include .next in turborepo build outputs

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -3,7 +3,7 @@
 	"tasks": {
 		"build": {
 			"dependsOn": ["^build"],
-			"outputs": ["dist/**"]
+			"outputs": ["dist/**", ".next/**"]
 		},
 		"dev": {
 			"cache": false,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Include the .next directory in Turborepo build outputs so Next.js artifacts are cached alongside dist. This improves cache hits and speeds up builds for tasks that depend on Next.js output.

<sup>Written for commit 97b5013c560c50b4811bf4563cc5a24e65bf2afe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

