### PR TITLE
chore: remove github release from release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,22 +69,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Create GitHub Releases
-        if: steps.changesets.outputs.published == 'true'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const publishedPackages = JSON.parse('${{ steps.changesets.outputs.publishedPackages }}');
-            for (const pkg of publishedPackages) {
-              const tag = `${pkg.name}@${pkg.version}`;
-              await github.rest.repos.createRelease({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                tag_name: tag,
-                name: tag,
-                body: `See [CHANGELOG](https://github.com/${context.repo.owner}/${context.repo.repo}/blob/master/packages/vs3/CHANGELOG.md) for details.`,
-                draft: false,
-                prerelease: false,
-              });
-            }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the GitHub Releases step from the release workflow to simplify CI and stop auto-creating releases. Changesets publishing to npm is unchanged; we just no longer create GitHub Releases.

<sup>Written for commit 5ba83dc6cf9c726ab480b8bd4b60806c5ae8c5fb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

