### PR TITLE
refactor: rename docs app

### DIFF
--- a/apps/docs/lib/layout.shared.tsx
+++ b/apps/docs/lib/layout.shared.tsx
@@ -3,7 +3,8 @@ import type { BaseLayoutProps } from "fumadocs-ui/layouts/shared";
 export function baseOptions(): BaseLayoutProps {
 	return {
 		nav: {
-			title: "My App",
+			title: "vs3",
 		},
+		githubUrl: "https://github.com/chris23lngr/vs3",
 	};
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Rename the docs app in the nav to "vs3" and add a GitHub link to https://github.com/chris23lngr/vs3 to match the new branding.

<sup>Written for commit 85d8c43cd24f462fe1e42fb49c72ae503d3633b9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

