### PR TITLE
feat(docs): add mobile layout

### DIFF
--- a/apps/docs/app/(app)/docs/[[...slug]]/page.tsx
+++ b/apps/docs/app/(app)/docs/[[...slug]]/page.tsx
@@ -88,12 +88,12 @@ export default async function Page(props: {
 		>
 			<div className="flex min-w-0 flex-1 flex-col">
 				<div className="h-(--top-spacing) shrink-0" />
-				<div className="mx-auto flex w-full min-w-0 max-w-[40rem] flex-1 flex-col gap-6 px-4 py-6 text-neutral-800 md:px-0 lg:py-8 dark:text-neutral-300">
+				<div className="mx-auto flex w-full min-w-0 max-w-[40rem] flex-1 flex-col gap-6 px-4 py-6 text-neutral-800 lg:py-8 dark:text-neutral-300">
 					<div className="flex flex-col gap-2">
 						<div className="flex flex-col gap-2">
 							<div className="flex items-center justify-between md:items-start">
 								<PageTitle className="scroll-m-24">{doc.title}</PageTitle>
-								<div className="docs-nav flex items-center gap-2">
+								<div className="docs-nav hidden items-center gap-2 md:flex">
 									<div className="ml-auto flex gap-2">
 										<LLMCopyButton markdownUrl={`${page.url}.mdx`} />
 										<ViewOptions
@@ -107,12 +107,8 @@ export default async function Page(props: {
 							{doc.description && <PageDescription>{doc.description}</PageDescription>}
 						</div>
 					</div>
-					<div className="w-full flex-1 pb-16 *:data-[slot=alert]:first:mt-0 sm:pb-0">
+					<div className="flex-1 pb-16 *:data-[slot=alert]:first:mt-0 sm:pb-0">
 						<MDX components={components} />
-					</div>
-					<div className="mt-8 grid grid-cols-2 gap-4">
-						<div></div>
-						<div></div>
 					</div>
 					<div className="grid grid-cols-2 gap-8">
 						<div className="flex items-start justify-start">
@@ -145,7 +141,7 @@ export default async function Page(props: {
 					</div>
 				</div>
 			</div>
-			<div className="sticky top-24 h-[calc(100svh-var(--header-height))] w-72 overflow-y-auto">
+			<div className="sticky top-24 hidden h-[calc(100svh-var(--header-height))] w-72 overflow-y-auto xl:block">
 				{doc.toc?.length ? (
 					<div className="no-scrollbar flex flex-col gap-8 overflow-y-auto px-8">
 						<DocsToc toc={doc.toc} />

--- a/apps/docs/app/(app)/docs/layout.tsx
+++ b/apps/docs/app/(app)/docs/layout.tsx
@@ -1,4 +1,5 @@
 import { DocsFooter } from "@/components/docs-footer";
+import { DocsNav } from "@/components/docs-nav";
 import { DocsSidebar } from "@/components/docs-sidebar";
 import { SiteNav } from "@/components/site-nav";
 import { SidebarProvider } from "@/components/ui/sidebar";
@@ -9,13 +10,13 @@ export default function Layout({ children }: LayoutProps<"/docs">) {
 	return (
 		<SidebarProvider>
 			<DocsSidebar tree={source.getPageTree()} />
-			<main className="relative flex-1">
-				<SiteNav
+			<main className="relative min-w-0 flex-1">
+				<DocsNav
 					className="sticky top-0 z-20 border-border border-b bg-background"
-					items={SiteConfig.nav.items}
+					// items={SiteConfig.nav.items}
 				/>
 				{children}
-				<DocsFooter />
+				{/* <DocsFooter /> */}
 			</main>
 		</SidebarProvider>
 	);

--- a/apps/docs/components/docs-nav.tsx
+++ b/apps/docs/components/docs-nav.tsx
@@ -1,0 +1,20 @@
+import { cn } from "@/lib/utils";
+import { Nav } from "./nav";
+import { SidebarTrigger } from "./ui/sidebar";
+
+export function DocsNav({
+	className,
+	...props
+}: React.ComponentProps<typeof Nav>) {
+	return (
+		<Nav
+			className={cn(
+				"sticky top-0 z-20 w-full border-border border-b bg-background",
+				className,
+			)}
+			{...props}
+		>
+			<SidebarTrigger className={"md:hidden"} />
+		</Nav>
+	);
+}

--- a/apps/docs/components/docs-sidebar.tsx
+++ b/apps/docs/components/docs-sidebar.tsx
@@ -49,7 +49,6 @@ export function DocsSidebar({
 	return (
 		<Sidebar
 			className="sticky top-0 h-svh border-border border-r border-dashed bg-transparent"
-			collapsible="none"
 			{...props}
 		>
 			<SidebarHeader className="flex h-(--header-height) flex-row items-center justify-center border-b">

--- a/apps/docs/components/nav.tsx
+++ b/apps/docs/components/nav.tsx
@@ -1,0 +1,32 @@
+import Link from "next/link";
+import type React from "react";
+import { cn } from "@/lib/utils";
+
+export function Nav({ className, ...props }: React.ComponentProps<"nav">) {
+	return (
+		<nav
+			className={cn(
+				"mx-auto flex h-(--header-height) w-full items-center justify-start px-8 py-6",
+				className,
+			)}
+			data-slot="nav"
+			{...props}
+		/>
+	);
+}
+
+export function NavItem({
+	className,
+	...props
+}: React.ComponentProps<typeof Link>) {
+	return (
+		<Link
+			className={cn(
+				"group/nav-item flex items-center justify-center gap-2 font-medium text-sm text-zinc-600 transition-colors hover:text-violet-600 dark:text-zinc-200 dark:hover:text-violet-500",
+				className,
+			)}
+			data-slot="nav-item"
+			{...props}
+		/>
+	);
+}

--- a/apps/docs/components/site-nav.tsx
+++ b/apps/docs/components/site-nav.tsx
@@ -3,6 +3,7 @@ import type React from "react";
 import type { JSX } from "react";
 import { cn } from "@/lib/utils";
 import { ThemeToggle } from "./theme-toggle";
+import { SidebarTrigger } from "./ui/sidebar";
 
 export function SiteNav({
 	className,
@@ -20,7 +21,7 @@ export function SiteNav({
 			data-slot="site-nav"
 			{...props}
 		>
-			<div className="ml-auto flex items-center justify-center gap-8 [&_svg]:size-4 [&_svg]:fill-zinc-600 [&_svg]:group-hover/nav-item:fill-violet-600">
+			<div className="ml-auto hidden items-center justify-center gap-8 md:flex [&_svg]:size-4 [&_svg]:fill-zinc-600 [&_svg]:group-hover/nav-item:fill-violet-600">
 				{items.map(({ href, icon: Icon, label }) => (
 					<Link
 						className="group/nav-item flex items-center justify-center gap-2 font-medium text-sm text-zinc-600 transition-colors hover:text-violet-600 dark:text-zinc-200 dark:hover:text-violet-500"

--- a/apps/docs/content/docs/(root)/index.mdx
+++ b/apps/docs/content/docs/(root)/index.mdx
@@ -32,3 +32,31 @@ Thank you for your interest in `vs3`! We highly welcome contributions from the c
 
 - [`@better-auth`](https://better-auth.com) inspired the API design and package structure. We also use `better-fetch` and `better-call` for server-client communication.
 - [`fumadocs`](https://www.fumadocs.dev/) for providing an excellent documentation framework.
+
+```ts
+import { createStorage } from "vs3";
+
+const storage = createStorage({
+    bucket: "my-bucket",
+    adapter: aws({
+        region: "us-east-1",
+    }),
+});
+```
+
+<Callout type="info">
+  `vs3` is currently in beta. The API will likely change before the first stable release. We strongly discourage you from using it in production but we'd love to hear your feedback and suggestions.
+</Callout>
+
+<CodeTabs groupId="framework" defaultValue="nextjs" values={["nextjs", "nuxt"]}>
+  <CodeTabsContent value="nextjs">
+    ```ts
+    import { createStorage } from "vs3";
+    ```
+  </CodeTabsContent>
+  <CodeTabsContent value="nuxt">
+    ```ts
+    import { createStorage } from "vs3";
+    ```
+  </CodeTabsContent>
+</CodeTabs>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added a mobile-friendly docs layout with a sticky nav and sidebar toggle. Hid desktop-only actions and the TOC on small screens to reduce clutter.

- **New Features**
  - New DocsNav with a mobile SidebarTrigger.
  - Responsive visibility: action buttons hidden on mobile; TOC only on xl screens.
  - Expanded docs index with code snippets, a beta callout, and framework tabs.

- **Refactors**
  - Replaced SiteNav with DocsNav and introduced a shared Nav component.
  - Adjusted layout (min-w-0, spacing) and simplified sidebar behavior.

<sup>Written for commit 40fd23c489ef31c9ceaf3f0fac75ecb47e68af32. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

